### PR TITLE
Close tools menu when clicking somewhere else

### DIFF
--- a/script.js
+++ b/script.js
@@ -14,3 +14,10 @@ jQuery(function () {
         event.preventDefault();
     });
 });
+
+jQuery('body').not(jQuery('.notos-toggle').children()).on('click', function(event) {
+    const $toggle = jQuery('input.notos-toggle');
+    if (event.target !== document.getElementById('notos__sitetools') && $toggle.prop('checked')) {
+        $toggle.prop('checked', false);
+    }
+});


### PR DESCRIPTION
For some reason it is no longer possible to close the menu by clicking on the toggle / the menu label.