### PR TITLE
Remove labels in tools menu

### DIFF
--- a/css/header-tools.less
+++ b/css/header-tools.less
@@ -32,20 +32,6 @@
                 background-color: @ini_header_text;
                 border: 1px solid @ini_border;
 
-                b {
-                    color: @ini_text;
-                    opacity: 0.2;
-                    font-size: 90%;
-                    padding-left: 1rem;
-                    white-space: nowrap;
-                    writing-mode: vertical-rl;
-
-                    position: absolute;
-                    right: 0;
-
-                    padding-top: 0.25rem;
-                }
-
                 ul {
                     list-style: none;
                     padding: 0;

--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -36,16 +36,13 @@
                             <input type="checkbox" class="notos-toggle" id="notos__sitetools">
                             <div>
                                 {% if _SERVER.REMOTE_USER or not conf.tpl.notos.hide_tools %}
-                                <b>{{ lang.page_tools }}</b>
                                 <ul>
                                     {{ TPL.menu('page').getListItems('', false)|raw }}
                                 </ul>
-                                <b>{{ lang.site_tools }}</b>
                                 <ul>
                                     {{ TPL.menu('site').getListItems('', false)|raw }}
                                 </ul>
                                 {% endif %}
-                                <b>{{ lang.user_tools }}</b>
                                 <ul>
                                     {{ TPL.menu('user').getListItems('', false)|raw }}
                                 </ul>


### PR DESCRIPTION
The labels are too long to be displayed correctly in many languages